### PR TITLE
Remove unused, nonexistent dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-canvas-api",
-  "version": "1.3.9",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7947,11 +7947,6 @@
           "dev": true
         }
       }
-    },
-    "save-dev": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/save-dev/-/save-dev-2.0.0.tgz",
-      "integrity": "sha1-T4wGcD1io/dlcVliNwBbEdVt9Q4="
     },
     "sax": {
       "version": "1.2.4",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "prompts": "^0.1.14",
     "ramda": "^0.25.0",
     "request": "^2.88.0",
-    "request-promise": "^4.2.4",
-    "save-dev": "^2.0.0"
+    "request-promise": "^4.2.4"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
The `save-dep` package [no longer exists](https://libraries.io/npm/save-dev) and seems to have been unused anyway. This removes the dependency so that consumers can continue using this package.