### PR TITLE
add getOptions: modules &  discussions 

### DIFF
--- a/source/getDiscussionTopics.js
+++ b/source/getDiscussionTopics.js
@@ -1,15 +1,23 @@
 import fetchAll from './internal/fetchAll'
+import buildOptions from './internal/util'
+
+require('dotenv').config()
 
 const canvasDomain = process.env.CANVAS_API_DOMAIN
 
 /**
  * Retrives all discussion topics in course
  * @param {Number} courseId the course id.
+ * @param {Array} options an array of options to include.
  * @return {Promise} A promise that resolves to a list of Discussion topics
  */
 
-const getDiscussionTopics = async courseId => {
-  return fetchAll(canvasDomain + `/courses/${courseId}/discussion_topics`)
+const getDiscussionTopics = async (courseId, ...options) => {
+  return fetchAll(
+    canvasDomain +
+      `/courses/${courseId}/discussion_topics?` +
+      buildOptions(options)
+  )
 }
 
 export default getDiscussionTopics

--- a/source/internal/getOptions.js
+++ b/source/internal/getOptions.js
@@ -90,7 +90,37 @@ const getOptions = {
     graded_assessments: 'include=graded_assessments',
     peer_assessments: 'include=peer_assessments',
     data_assessment: 'style=full'
+  },
+  module: {
+    include: {
+      items: 'include[]=items',
+      content_details: 'include[]=content_details'
+    }
+  },
+  discussion: {
+    include: {
+      all_dates: 'include[]=all_dates',
+      sections: 'include[]=sections',
+      sections_user_count: 'include[]=sections_user_count',
+      overrides: 'include[]=overrides'
+    },
+    order_by: {
+      position: 'orderby=position',
+      recent_activity: 'orderby=recent_activity',
+      title: 'orderby=title'
+    },
+    scope: {
+      locked: 'scope=locked',
+      unlocked: 'scope=unlocked',
+      pinned: 'scope=pinned',
+      unpinned: 'scope=unpinned'
+    },
+    only_announcements: 'only_announcements=true',
+    filter_by: {
+      all: 'filter_by=all',
+      unread: 'filter_by=unread'
+    }
   }
-}
+};
 
-export default getOptions
+export default getOptions;

--- a/src/getDiscussionTopics.js
+++ b/src/getDiscussionTopics.js
@@ -1,15 +1,20 @@
 var fetchAll = require('./internal/fetchAll');
 
+var buildOptions = require('./internal/util');
+
+require('dotenv').config();
+
 const canvasDomain = process.env.CANVAS_API_DOMAIN;
 
 /**
  * Retrives all discussion topics in course
  * @param {Number} courseId the course id.
+ * @param {Array} options an array of options to include.
  * @return {Promise} A promise that resolves to a list of Discussion topics
  */
 
-const getDiscussionTopics = async courseId => {
-  return fetchAll(canvasDomain + `/courses/${courseId}/discussion_topics`);
+const getDiscussionTopics = async (courseId, ...options) => {
+  return fetchAll(canvasDomain + `/courses/${courseId}/discussion_topics?` + buildOptions(options));
 };
 
 module.exports = getDiscussionTopics;

--- a/src/internal/getOptions.js
+++ b/src/internal/getOptions.js
@@ -90,6 +90,36 @@ const getOptions = {
     graded_assessments: 'include=graded_assessments',
     peer_assessments: 'include=peer_assessments',
     data_assessment: 'style=full'
+  },
+  module: {
+    include: {
+      items: 'include[]=items',
+      content_details: 'include[]=content_details'
+    }
+  },
+  discussion: {
+    include: {
+      all_dates: 'include[]=all_dates',
+      sections: 'include[]=sections',
+      sections_user_count: 'include[]=sections_user_count',
+      overrides: 'include[]=overrides'
+    },
+    order_by: {
+      position: 'orderby=position',
+      recent_activity: 'orderby=recent_activity',
+      title: 'orderby=title'
+    },
+    scope: {
+      locked: 'scope=locked',
+      unlocked: 'scope=unlocked',
+      pinned: 'scope=pinned',
+      unpinned: 'scope=unpinned'
+    },
+    only_announcements: 'only_announcements=true',
+    filter_by: {
+      all: 'filter_by=all',
+      unread: 'filter_by=unread'
+    }
   }
 };
 


### PR DESCRIPTION
#23 #22 

- Adds getOptions for modules and discussions.
- Adds options parameter for getDiscussionTopics


- [x] Import works on index.js
- [x] Functionality fine for getDiscussionTopics (backwards compatible, just drops arg) 